### PR TITLE
modified three files that were buggy.

### DIFF
--- a/hyprland.conf
+++ b/hyprland.conf
@@ -112,7 +112,7 @@ decoration {
     }
 }
 
-blurls = waybar
+#blurls = waybar
 
 animations {
     enabled = true
@@ -153,6 +153,8 @@ bind = $mainMod SHIFT,  Space,        togglefloating
 bind = $mainMod,        F,            fullscreen
 bind = $mainMod,        Return, exec, $term
 bind = $mainMod,        T,      exec, $altTerm
+bind = $mainMod,        W,      exec, $browser
+bind = $mainMod SHIFT,  W,      exec, $altBrowser
 bind = $mainMod,        N,      exec, $notes
 bind = $mainMod SHIFT,  N,      exec, $altNotes
 bind = $mainMod,        X,      exec, $logout

--- a/install.sh
+++ b/install.sh
@@ -78,6 +78,7 @@ read -r VAR
 
 case "$VAR" in
 [yY][eE][sS] | [yY]) # Accept 'y', 'Y', 'yes', or 'Yes'
+    cd $CLONE_DIR
     echo -e "${GREEN}🔧 Running setup.sh...${NC}"
     if [ -f "setup.sh" ]; then
         chmod +x setup.sh

--- a/scripts/screenshot
+++ b/scripts/screenshot
@@ -26,31 +26,31 @@ countdown() {
 
 # Take Screenshots
 shotNow() {
-    cd ${dir} && grim -
+    cd ${dir} && grim - | tee "$file" | wl-copy
     notify_view
 }
 
 shotin5() {
     countdown '5'
-    sleep 1 && cd ${dir} && grim -
+    sleep 1 && cd ${dir} && grim - | tee "$file" | wl-copy
     notify_view
 }
 
 shotin10() {
     countdown '10'
-    sleep 1 && cd ${dir} && grim -
+    sleep 1 && cd ${dir} && grim - | tee "$file" | wl-copy
     notify_view
 }
 
 shotWindow() {
     win_pos=$(hyprctl activewindow | grep 'at:' | cut -d':' -f2 | tr -d ' ' | tail -n1)
     win_size=$(hyprctl activewindow | grep 'size:' | cut -d':' -f2 | tr -d ' ' | tail -n1 | sed s/,/x/g)
-    cd ${dir} && grim -g "$win_pos $win_size" -
+    cd ${dir} && grim -g "$win_pos $win_size" - | tee "$file" | wl-copy
     notify_view
 }
 
 shotArea() {
-    cd ${dir} && grim -g "$(slurp -b 1B1F28CC -c E06B74ff -s C778DD0D -w 2)" -
+    cd ${dir} && grim -g "$(slurp -b 1B1F28CC -c E06B74ff -s C778DD0D -w 2)" - | tee "$file" | wl-copy
     notify_view
 }
 


### PR DESCRIPTION
# Files that were buggy:
1- `hyprland.conf`:
 - Variables for browsers such as Firefox and Chromium weren't used.

2- `scripts/screenshot`:
 - The script used grim but didn't append the content to the .png file specified at the beginning.

3- `install.sh`:
 - when trying to run the `setup.sh` after the main script finishes it fails because the file is inside the cloned repository and not the current working directory.